### PR TITLE
mise à jour du lien vers le bulletin d'adhésion

### DIFF
--- a/content/posts/syndicat.md
+++ b/content/posts/syndicat.md
@@ -46,6 +46,6 @@ Les prises de contact des salariés sont d’abord reçues par le <abbr title="R
 
 Si vous vous reconnaissez dans nos valeurs, et qu'avec nous, vous voulez défendre vos droits, vous pouvez adhérer à notre section syndicale.
 
-Vous pouvez adhérer directement via [le bulletin Solidaires Informatique](https://solidairesinformatique.org/wp-content/uploads/2023/07/BulletinAdhesion.pdf). Autrement, si vous avez des questions ou voulez de l'accompagnement, vous pouvez également [nous contacter](/page/contact).
+Vous pouvez adhérer directement via [le bulletin Solidaires Informatique](https://adhesion.solidairesinformatique.org?SIRET=44163769100128). Autrement, si vous avez des questions ou voulez de l'accompagnement, vous pouvez également [nous contacter](/page/contact).
 
 ![Uni·es on est plus fort·es ! Syndique-toi !](/img/unies-on-est-plus-fortes.png)


### PR DESCRIPTION
Mise à jour du lien vers le bulletin d'adhésion pour utiliser le nouveau formulaire d'adhésion.

J'ai mis le SIRET du siège de Lucca dans le lien (`SIRET=44163769100128`) pour que ça soit pré-rempli dans le formulaire.

![image](https://github.com/user-attachments/assets/fb1cb217-6bdf-4c5e-a7ec-7127ff181d4d)


Si ce n'est pas pertinent n'hésitez pas à l'enlever (ou à me demander de l'enlever).

Si vous préférez continuer à pointer vers un PDF idéalement il faut remplacer le lien par celui-ci : 

```
https://adhesion.solidairesinformatique.org/BulletinAdhesion.pdf
```